### PR TITLE
Fix duplicate keys in single-line dicts

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -1,14 +1,14 @@
 /**
  * This package provides a parser for HUML (Human Markup Language),
  * a strict, human-readable data format.
- * 
+ *
  * HUML (Human Markup Language) enforces:
  * - Strict indentation (2 spaces)
  * - No trailing spaces
  * - Explicit type indicators (: for scalar, :: for vector)
  * - Clear multiline string delimiters (``` preserves spacing, """ strips)
  * - ALL strings must be quoted with double quotes
- * 
+ *
  * Key HUML concepts:
  * - [] and {} are ONLY for empty collections
  * - Inline lists: key:: "val1", "val2", 3, true (NO brackets)
@@ -358,6 +358,9 @@ class Parser {
                 this.advance(1);
                 this.assertSpace('in inline dict');
 
+                if (key in result) {
+                    throw this.error(`duplicate key '${key}' in dict`);
+                }
                 result[key] = this.parseValue(0);
             } else {
                 result.push(this.parseValue(0));

--- a/decode_tests.js
+++ b/decode_tests.js
@@ -8,15 +8,20 @@ import { parse } from './decode.js';
 test('Assertions', async (t) => {
   const runAssertion = async (name, input, errorExpected) => {
     await t.test(name, () => {
+      let failure = '';
       try {
         const result = parse(input);
         if (errorExpected) {
-          assert.fail('expected error but got none');
+          failure = 'expected error but got none';
         }
       } catch (err) {
         if (!errorExpected) {
-          assert.fail(`unexpected error: ${err.message}`);
+          failure = `unexpected error: ${err.message}`;
         }
+      }
+      if (failure !== '') {
+        // This throws, so don't call it in the catch above.
+        assert.fail(failure);
       }
     });
   };


### PR DESCRIPTION
The [spec](https://huml.io/specifications/v0-1-0/#data-types) disallows duplicate keys in dicts, whether multiline or single. This PR fixes a bug where duplicate keys were allowed in single-line dicts.

Includes #1. Test case added in https://github.com/huml-lang/tests/pull/1. 🙇‍♂️