### PR TITLE
add key start check

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -387,6 +387,8 @@ class Parser {
 
         if (this.peekChar(this.pos) === '"') {
             return this.parseString();
+        } else if (!this.isKeyStart()) {
+            throw this.error(`invalid character '${this.data[this.pos]}', expected key`);
         }
 
         const start = this.pos;


### PR DESCRIPTION
fix below test cases
```json
{"name": "inline_dict_invalid_key", "input": "dict:: 1: true", "error": true},
{"name": "inline_dict_invalid_key", "input": "dict:: _a: true", "error": true},
```
related to: https://github.com/huml-lang/tests/pull/2